### PR TITLE
Added excludeFiles field to reference overview

### DIFF
--- a/references/migration-plans/tomcat-migration-plan.md
+++ b/references/migration-plans/tomcat-migration-plan.md
@@ -17,8 +17,9 @@ _Appears in:_
 | --- | --- |
 | `name` _string_ | Name of the Tomcat server. |
 | `catalinaBase` _string_ | Value of CATALINA_BASE. |
-| `catalinaHome` _string_ | Value of CATALINA_HOME .|
+| `catalinaHome` _string_ | Value of CATALINA_HOME. |
 | `images` _[Image](#image) array_ | A list of container images, each for a Tomcat host |
+| `excludeFiles` _string_ | Exclude files from migration. |
 
 ### ConfigResource
 _Appears in:_


### PR DESCRIPTION
Added excludeFiles field to the overview
Description is the same as the comment in migration plane Fixed also catalinaHome (redunded space)