### PR TITLE
Create assess_mfit1.sh

### DIFF
--- a/scripts/assess_mfit1.sh
+++ b/scripts/assess_mfit1.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mkdir m2c
+cd m2c
+
+VERSION=`wget -O - https://mfit-release.storage.googleapis.com/latest`
+
+wget https://mfit-release.storage.googleapis.com/${VERSION}/mfit-linux-collect.sh
+chmod +x mfit-linux-collect.sh
+
+wget https://mfit-release.storage.googleapis.com/${VERSION}/mfit
+chmod +x mfit
+
+# Run collection script locally
+sudo ./mfit-linux-collect.sh
+
+# Import the VM collection details to mFIT DB
+#./mfit discover import m2c-collect-*-*.tar
+
+# Assess and generate a detailed HTML report
+./mfit report --full --format html > mfit-report.html
+
+# Assess and generate a JSON report
+./mfit report --format json > mfit-report.json


### PR DESCRIPTION
commented 
#./mfit discover import m2c-collect-*-*.tar

mfit descover is important step for collecting vm migration details but due to following error commenting the above line to validate this error 

MFIT migration error  after running this command from gloud cli - curl -s https://raw.githubusercontent.com/GoogleCloudPlatform/migrate-to-containers/main/scripts/assess_mfit.sh | bash

2023-02-17T01:51:04.473627409Z	high	ReportEvent	{"payload":  "aid=mfit&aip=1&an=mfit&av=1.14.0&cd1=&cd2=CloudShell&cd3=true&cid=b3d773e1-d45b-4f5d-89a9-f148d3b2b227&ds=cli&ea=discover. import&ec=Command&npa=1&t=event&tid=UA-210217715-1&ua=mfit%2F1.14.0+%28linux%3B+amd64%29&ul=en-US&v=1"} {"version": "1.14.0", "error": "1 error occurred:\n\t* error importing 'm2c-collect-*-*.tar': 1 error occurred:\n\t*  failed collecting 'ImportVM': could not read file 'm2c-collect-*-*.tar':  open m2c-collect-*-*.tar: no such file or directory\n\n\n\n"} 2023-02-17T01:51:04.491882608Z	high	mfit.discover.import